### PR TITLE
Add path parameters

### DIFF
--- a/harness/account.go
+++ b/harness/account.go
@@ -16,6 +16,8 @@ type Config struct {
 	AccountIdentifier string              `yaml:"accountIdentifier"`
 	ApiKey            string              `yaml:"apiKey"`
 	TargetProjects    []string            `yaml:"targetProjects"`
+	PipelinePaths     []string            `yaml:"pipelinePaths"`
+	TemplatePaths     []string            `yaml:"templatePaths"`
 	ExcludeProjects   []string            `yaml:"excludeProjects"`
 	GitDetails        GitDetails          `yaml:"gitDetails"`
 	FileStoreConfig   FileStoreConfig     `yaml:"fileStoreConfig"`


### PR DESCRIPTION
## Description
This repo is forked from a Harness repo for migrating inline type entities (currently only support Pipelines and Templates)
This PR add paths parameters for templates and pipelines in order that we can specify it by ourselves as we wish when we use the migrator. More details can be found in the linked Jira task.

## Related Jira task
https://mlc.atlassian.net/browse/RMPSRE-481